### PR TITLE
Add an option to skip checking of troublesome modes

### DIFF
--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -138,6 +138,11 @@ against.")
   :type 'boolean
   :group 'parinfer-rust-mode)
 
+(defcustom parinfer-rust-check-troublesome-modes t
+  "Whether to check for troublesome modes after enabling `parinfer-rust-mode'."
+  :type 'boolean
+  :group 'parinfer-rust-mode)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -381,7 +386,8 @@ Checks if MODE is a valid Parinfer mode, and uses
 (defun parinfer-rust-mode-enable ()
   "Enable Parinfer."
   (setq-local parinfer-rust-enabled t)
-  (parinfer-rust--detect-troublesome-modes)
+  (when parinfer-rust-check-troublesome-modes
+    (parinfer-rust--detect-troublesome-modes))
   (parinfer-rust--set-default-state)
   (setq-local parinfer-rust--mode parinfer-rust-preferred-mode)
   (advice-add 'undo :around #'parinfer-rust--track-undo)


### PR DESCRIPTION
I usually use emacs in daemon mode and handle `electric-pairs-mode` using hooks. And I disable that mode when I load `parinfer-mode`. The problem is that the `parinfer-mode` detects the `electric-pairs-mode` and keeps prompting me with an option to disable it, even though it will be disabled automatically.
So I decided to add a `parinfer-rust-check-troublesome-modes` option which defaults to `t`, but can be set to `nil` so the check will be skipped.