### PR TITLE
Remove test-helper provide

### DIFF
--- a/test/indent-parinfer-tests.el
+++ b/test/indent-parinfer-tests.el
@@ -23,7 +23,6 @@
 ;; Tests for indent-mode
 
 ;;; Code:
-(require 'test-helper)
 
 (ert-deftest parinfer-indent-0 ()
  (let ((before

--- a/test/paren-parinfer-tests.el
+++ b/test/paren-parinfer-tests.el
@@ -23,8 +23,6 @@
 ;; Tests for paren-mode
 
 ;;; Code:
-(require 'test-helper)
-
 (ert-deftest parinfer-paren-0 ()
  (let ((before
 "(let [foo 1]

--- a/test/smart-parinfer-tests.el
+++ b/test/smart-parinfer-tests.el
@@ -23,9 +23,6 @@
 ;; Tests for smart-mode
 
 ;;; Code:
-
-(require 'test-helper)
-
 (ert-deftest parinfer-smart-0 ()
  (let ((before
 "(let [a 1

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -250,6 +250,4 @@ extracted from the json-alist."
       (simulate-parinfer-in-another-buffer--with-changes test-string mode changes)
     (simulate-parinfer-in-another-buffer--without-changes test-string mode)))
 
-
-(provide 'test-helper)
 ;;; test-helper.el ends here

--- a/test/user-submitted-cases.el
+++ b/test/user-submitted-cases.el
@@ -23,8 +23,6 @@
 ;; Tests user submitted cases
 
 ;;; Code:
-
-(require 'test-helper)
 (require 'paredit)
 (require 'clojure-mode)
 ;; This covers issue #8


### PR DESCRIPTION
It's autoloaded by ert-runner and used within test files

Closes #29