### PR TITLE
Disable parinfer-rust-mode if tabs are found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elpa-emacs
 .cask/*
+.node_modules/

--- a/readme.org
+++ b/readme.org
@@ -159,7 +159,7 @@ Options:
 ** Known Issues
    - Multiple cursors do not work as intended
    - Does not play well with other modes that insert parens or manage whitespace. If you have modes like electric-pair-mode or hungry-delete-mode enabled, you may want to disable them for any mode that has parinfer-rust-mode enabled. To help users work around this we offer to disable known troublesome modes if we detect them.
-*** Out of Memory 
+*** Out of Memory
 This is still alpha software and parinfer-rust has been known to get ~Out of Memory~ warnings and cause Emacs to crash, so use at your own risk.
 + I'm maintaining a [[https://github.com/justinbarclay/parinfer-rust][fork]] of parinfer-rust, that patches the libraries ability to cause an ~Out of Memory~ error.
 + In fairness to the maintainer of parinfer-rust, the reason that the library is crashing is due to the changes I am passing to the library. Which admittedly, can be non-sensical from parinfer's perspective.

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -249,5 +249,4 @@ extracted from the json-alist."
   (if changes
       (simulate-parinfer-in-another-buffer--with-changes test-string mode changes)
     (simulate-parinfer-in-another-buffer--without-changes test-string mode)))
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
This gives a warning to users if tabs are found in the buffer during the parinfer-rust-mode initialization and then disables parinfer mode. Parinfer-rust, and parinfer in general does not handle tabs as whitespace in the buffer and causes sexp to shift wildly out of alignment. See #32 for an example