### PR TITLE
parinfer-rust---test-p not a symbol

### DIFF
--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -72,7 +72,7 @@ offer to download the LIB-NAME to LIBRARY-LOCATION."
                    current-version
                    supported-version))
              (and
-              (not (bound-and-true-p (parinfer-rust--test-p)))
+              (not (parinfer-rust--test-p))
               (yes-or-no-p parinfer-rust--outdated-version)))
     (parinfer-rust--download-from-github supported-version library-location lib-name)
     (message "A new version has been downloaded, you will need to reload Emacs for the changes to take effect.")))


### PR DESCRIPTION
> I get another error when using the version cloned from the parinfer-rust git repo and building using the instructions given there:
> ```emacs-lisp
> Debugger entered--Lisp error: (wrong-type-argument symbolp (parinfer-rust--test-p))
>    boundp((parinfer-rust--test-p))
>    parinfer-rust--check-version("0.4.4-beta" "0.4.3" "/home/jthoren/.emacs.d/.local/etc/parinfer-rust/li..." nil)
>    parinfer-rust-mode()
>    run-hooks(change-major-mode-after-body-hook prog-mode-hook emacs-lisp-mode-hook)
>    apply(run-hooks (change-major-mode-after-body-hook prog-mode-hook emacs-lisp-mode-hook))
>    run-mode-hooks(emacs-lisp-mode-hook)
>    ...
> ```
> Does this indicate that the version I get when compiling parinfer-rust from the git repo is incompatible with parinfer-rust-mode?

_Originally posted by @johanthoren in https://github.com/justinbarclay/parinfer-rust-mode/issues/37#issuecomment-792343900_

After a refactor test-p is no longer a variable but is a function and therefore no longer needs to be ran through `bound-and-true`