### PR TITLE
Update readme.org to reflect name changes from 9f8e928c

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -150,7 +150,7 @@ Options:
   #+END_QUOTE
 - ~parinfer-rust-dim-parens~
 
-  Dim parentheses that are inferred by Parinfer in ~indent~ and ~smart~ modes. Color can be configured via ~parinfer-rust-dim-parens-face~.
+  Dim parentheses that are inferred by Parinfer in ~indent~ and ~smart~ modes. Color can be configured via the ~parinfer-rust-dim-parens~ face.
   #+BEGIN_QUOTE
   default: t
   #+END_QUOTE


### PR DESCRIPTION
As the title says, the commit 9f8e928c changes the name of the face used to configure the colouring of the dimmed parens, but the documentation in the readme.org was left unchanged.

This just fixes the name of face in the documentation, hopefully saving other people some initial confusion.

On a side note: Thanks for maintaining parinfer-rust-mode! I was using the elisp based parinfer implementation previously, and now that it is unmaintained, I'm glad that I have not to pass on the editing benefits parinfer grants.