### PR TITLE
fix: fix download link by only using latest version

### DIFF
--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -86,7 +86,7 @@ offer to download the LIB-NAME to LIBRARY-LOCATION."
              (and
               (not (parinfer-rust--test-p))
               (yes-or-no-p parinfer-rust--outdated-version)))
-    (parinfer-rust--download-from-github supported-versions library-location lib-name)
+    (parinfer-rust--download-from-github (car supported-versions) library-location lib-name)
     (message "A new version has been downloaded, you will need to reload Emacs for the changes to take effect.")))
 
 (defun parinfer-rust--download-from-github (parinfer-rust-version


### PR DESCRIPTION
`v(0.4.4 0.4.3)` does not seem to be a valid path for auto download

```
/bin/bash: -c: line 1: syntax error near unexpected token `('
/bin/bash: -c: line 1: `curl -L https://github.com/justinbarclay/parinfer-rust/releases/download/v(0.4.4 0.4.3)/parinfer-rust-linux.so -o /home/user/.emacs.d/.cache/parinfer-rust/parinfer-rust-linux.so'
```

close https://github.com/justinbarclay/parinfer-rust-mode/issues/75