### PR TITLE
Update options handling

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,5 +1,6 @@
 ((emacs-lisp-mode . ((fill-column . 100)
                      (indent-tabs-mode . nil)
+                     (lisp-indent-function . common-lisp-indent-function)
                      (sentence-end-double-space . nil)
                      (elisp-lint-indent-specs . ((describe . 1)
                                                  (it . 1))))))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        emacs_version: [ 26.3, 27.2, 28.2, 29.1, 29.2, release-snapshot ]
+        emacs_version: [ 27.2, 28.2, 29.1, 29.2, release-snapshot ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,4 @@ jobs:
     - name: Check emacs version
       run: emacs --version
     - name: Check
-      continue-on-error: true
       run: nix develop -c make test

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ version:
 download:
 ifeq (,$(wildcard $(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so))
 	mkdir -p $(HOME)/.emacs.d/parinfer-rust
-	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.5/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust-emacs/parinfer-rust-$(OS).so"
+	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.6-beta1/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust-emacs/parinfer-rust-$(OS).so"
 endif
 
 test: clean elpa version download build

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ version:
 download:
 ifeq (,$(wildcard $(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so))
 	mkdir -p $(HOME)/.emacs.d/parinfer-rust
-	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.6-beta1/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust-emacs/parinfer-rust-$(OS).so"
+	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.6-beta2/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so"
 endif
 
 test: clean elpa version download build

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ version:
 download:
 ifeq (,$(wildcard $(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so))
 	mkdir -p $(HOME)/.emacs.d/parinfer-rust
-	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.6-beta2/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so"
+	curl -L "https://github.com/justinbarclay/parinfer-rust-emacs/releases/download/v0.4.6/parinfer-rust-$(OS).so" -o "$(HOME)/.emacs.d/parinfer-rust/parinfer-rust-$(OS).so"
 endif
 
 test: clean elpa version download build

--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -1,6 +1,6 @@
 ;;; parinfer-rust-helper.el --- Helper functions for parinfer-rust-mode   -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2019-2020  Justin Barclay
+;; Copyright (C) 2019-2024  Justin Barclay
 
 ;; Author: Justin Barclay <justinbarclay@gmail.com>
 

--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -119,7 +119,7 @@ Uses PARINFER-RUST-VERSION to download a compatible version of the library."
                          lib-name)
                  (expand-file-name library-location)))
         (message "Installing %s v%s to %s" lib-name parinfer-rust-version library-location))
-    (message "Unable to download parinfer-rust library because curl is not on $PATH")))
+    (warn "Unable to download parinfer-rust library because curl is not on $PATH")))
 
 (defun parinfer-rust--is-active-minor-mode (minor-mode-maybe)
   "Return non-nil if MINOR-MODE-MAYBE is active in the current buffer."

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -143,7 +143,7 @@
 
 ;; 3. Run parinfer-rust and update the state of the buffer accordingly
 
-(defconst parinfer-rust-supported-versions '("0.4.6-beta" "0.4.3")
+(defconst parinfer-rust-supported-versions '("0.4.6-beta1")
   "The Supported versions of the parinfer-rust library.
 
 Versions of the library that `parinfer-rust-mode' was tested

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -143,7 +143,7 @@
 
 ;; 3. Run parinfer-rust and update the state of the buffer accordingly
 
-(defconst parinfer-rust-supported-versions '("0.4.6-beta2")
+(defconst parinfer-rust-supported-versions '("0.4.6")
   "The Supported versions of the parinfer-rust library.
 
 Versions of the library that `parinfer-rust-mode' was tested

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -143,7 +143,7 @@
 
 ;; 3. Run parinfer-rust and update the state of the buffer accordingly
 
-(defconst parinfer-rust-supported-versions '("0.4.6-beta1")
+(defconst parinfer-rust-supported-versions '("0.4.6-beta2")
   "The Supported versions of the parinfer-rust library.
 
 Versions of the library that `parinfer-rust-mode' was tested
@@ -264,7 +264,7 @@ node `(elisp)Replacing'"
                                                (:janet-long-strings boolean)
                                                (:comment-char string)
                                                (:string-delimiters (repeat string)))
-                                     :value-type (choice boolean string (vector string)))
+                                     :value-type (choice boolean string (repeat string)))
   "The available options to pass to the parinfer-rust library.
 
 These options are used to configure the behavior of the
@@ -314,8 +314,8 @@ The available options are:
     - Default: \";\"
 
   - `:string-delimiters' - the delimiters used for strings.
-    - Type: (vector string)
-    - Default: [\"\\\"\"]")
+    - Type: (repeat string)
+    - Default: (\"\\\"\")")
 
 
 (defvar parinfer-rust--default-options '(:force-balance nil
@@ -327,8 +327,8 @@ The available options are:
                                          :scheme-sexp-comments nil
                                          :janet-long-strings nil
                                          :comment-char ";"
-                                         :string-delimiters ["\""])
-  "The set of options parinfer-rust considers default.
+                                         :string-delimiters ("\""))
+   "The set of options parinfer-rust considers default.
 
 This is here mainly as reference for what is available to pass to
 the library and what needs to be changed for major mode specific

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -387,16 +387,15 @@ See `parinfer-rust--option-type' for a more complete explanation of the options.
 (defvar parinfer-rust-major-mode-options
   (list
    'clojure-mode parinfer-rust-clojure-options
-
+   'clojurec-mode parinfer-rust-clojure-options
+   'clojurescript-mode parinfer-rust-clojure-options
    'janet-mode parinfer-rust-janet-options
-
-   'lisp-mode parinfer-rust-lisp-options
-
+   'common-lisp-mode parinfer-rust-lisp-options
    'racket-mode parinfer-rust-racket-options
-
-   'guile-mode parinfer-rust-guile-options
-
-   'scheme-mode parinfer-rust-scheme-options)
+   'scheme-mode parinfer-rust-scheme-options
+   ;; This doesn't work - there is no guile mode but I am not sure what we can
+   ;; use to set guile specific options
+   'guile-mode parinfer-rust-guile-options)
   "Major mode specific options for that controls how the parinfer-rust library behaves.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -27,6 +27,12 @@
 
 ;; An intuitive editor mode to make paren management fun and easy without sacrificing power.
 
+;; Installation:
+;;
+;; If you're on Windows, Linux, or Arm Mac parinfer-rust will attempt to install the parinfer-rust
+;; library for you. However, if you want you can compile the library from source at:
+;; https://github.com/justinbarclay/parinfer-rust.
+
 ;; How it works:
 
 ;; Parinfer users the state of the buffer combined with the current mode (paren, indent, or smart)

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -363,6 +363,29 @@ parinfer."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Interfaces for parinfer-rust
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(defun parinfer-rust--set-options (previous-options new-options)
+  "Update the `PREVIOUS-OPTIONS' with values in the plist `NEW-OPTIONS'.
+
+This mutates the current reference to `PREVIOUS-OPTIONS'
+Ex:
+  (parinfer-rust--set-options parinfer-rust--previous-options ;; '((cursor-x . 1) (cursor-line . 1))
+                               '(cursor-x 2 cursor-line 2))
+;;=> '((cursor-x . 2) (cursor-line . 2))"
+  (mapcar (lambda (options)
+            ;; Note to self set-option might need to clone in order to keep old option immutable
+            (parinfer-rust-set-option previous-options
+                                      (car options)
+                                      (cadr options)))
+             ;; partition plist into key-value pairs
+          (seq-partition new-options 2)))
+
+;; Uncomment for example:
+;; (let ((options (parinfer-rust-make-option)))
+;;   (parinfer-rust--set-options
+;;    options
+;;    '(force-balance t comment-char "\\"))
+;;   (parinfer-rust-print-options options))
+
 ;; The change interface and associated functions for change tracking
 ;; can be found in parinfer-rust-changes.el
 (defun parinfer-rust--generate-options (old-options changes)

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -159,9 +159,8 @@ against and is known to be api compatible.")
   (declare-function parinfer-rust-new-options "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-make-request "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-execute "ext:parinfer-rust" t t)
-  (declare-function parinfer-rust-get-in-answer "ext:parinfer-rust" t t)
+  (declare-function parinfer-rust-get-answer "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-debug "ext:parinfer-rust" t t)
-  (declare-function parinfer-rust-print-error "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-version "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-set-option "ext:parinfer-rust" t t)
   (declare-function parinfer-rust-get-option "ext:parinfer-rust" t t)
@@ -596,13 +595,13 @@ CHANGES."
                                                                                   (point-max))
                                                   options))
              (answer (parinfer-rust-execute request))
-             (replacement-string (parinfer-rust-get-in-answer answer "text"))
-             (error-p (parinfer-rust-get-in-answer answer "error")))
+             (replacement-string (parinfer-rust-get-answer answer :text))
+             (error-p (parinfer-rust-get-answer answer :error)))
         (when (and (local-variable-if-set-p 'parinfer-rust--in-debug)
                    parinfer-rust--in-debug)
           (parinfer-rust-debug "./parinfer-rust-debug.txt" options answer))
         (if error-p
-            (message "%s" (parinfer-rust-print-error error-p)) ;; TODO handle errors
+            (message "%s" error-p) ;; TODO handle errors
           ;; This stops Emacs from flickering when scrolling
           (if (not (string-equal parinfer-rust--previous-buffer-text replacement-string))
               (save-mark-and-excursion
@@ -621,8 +620,8 @@ CHANGES."
                     (replace-buffer-contents new-buf 1))
                   (kill-buffer new-buf)
                   (undo-amalgamate-change-group change-group)))))
-        (when-let ((new-x (parinfer-rust-get-in-answer answer "cursor_x"))
-                   (new-line (parinfer-rust-get-in-answer answer "cursor_line")))
+        (when-let ((new-x (parinfer-rust-get-answer answer :cursor-x))
+                   (new-line (parinfer-rust-get-answer answer :cursor-line)))
           (parinfer-rust--reposition-cursor new-x new-line))
         (setq parinfer-rust--previous-options options)
         (when parinfer-rust--change-tracker

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -292,7 +292,7 @@ The available options are:
     - Type: boolean
     - Default: nil
 
-  - `:lisp-block-comments': recognize |lisp-style vline symbol|s.
+  - `:lisp-block-comments': recognize #|lisp-style block comments|#.
     - Type: boolean
     - Default: nil
 

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -137,7 +137,7 @@
 
 ;; 3. Run parinfer-rust and update the state of the buffer accordingly
 
-(defconst parinfer-rust-supported-versions '("0.4.5" "0.4.3")
+(defconst parinfer-rust-supported-versions '("0.4.6" "0.4.3")
   "The Supported versions of the parinfer-rust library.
 
 Versions of the library that `parinfer-rust-mode' was tested
@@ -245,6 +245,70 @@ node `(elisp)Replacing'"
 
 (define-obsolete-variable-alias 'parinfer-rust--buffer-replace-strategy 'parinfer-rust-buffer-replace-strategy "0.8.7")
 
+
+(defvar parinfer-rust--default-options '(lisp-vline-symbols nil
+                                         lisp-block-comments nil
+                                         guile-block-comments nil
+                                         scheme-sexp-comments nil
+                                         janet-long-strings nil
+                                         hy-bracket-strings nil))
+;; TODO: Make into a defcustom
+(defcustom parinfer-rust-major-mode-options
+  (list
+   'clojure-mode parinfer-rust--default-options
+
+   'janet-mode '(lisp-vline-symbols nil
+                 lisp-block-comments nil
+                 guile-block-comments nil
+                 scheme-sexp-comments nil
+                 janet-long-strings nil
+                 hy-bracket-strings nil)
+
+
+   'lisp-mode '(lisp-vline-symbols t
+                lisp-block-comments t
+                guile-block-comments nil
+                scheme-sexp-comments nil
+                janet-long-strings nil
+                hy-bracket-strings nil)
+
+   'racket-mode '(lisp-vline-symbols t
+                  lisp-block-comments t
+                  guile-block-comments nil
+                  scheme-sexp-comments t
+                  janet-long-strings nil
+                  hy-bracket-strings nil)
+
+   'guile-mode '(lisp-vline-symbols t
+                 lisp-block-comments t
+                 guile-block-comments t
+                 scheme-sexp-comments t
+                 janet-long-strings nil
+                 hy-bracket-strings nil)
+
+   'scheme-mode '(lisp-vline-symbols t
+                  lisp-block-comments t
+                  guile-block-comments nil
+                  scheme-sexp-comments t
+                  janet-long-strings nil
+                  hy-bracket-strings nil)
+   'hy-mode  '(lisp-vline-symbols nil
+               lisp-block-comments nil
+               guile-block-comments nil
+               scheme-sexp-comments nil
+               janet-long-strings nil
+               hy-bracket-strings t))
+  "Major mode specific options for `parinfer-rust-mode'."
+  :type '(plist :value-type (plist
+                             :key-type symbol
+                             :options (lisp-vline-symbols
+                                       lisp-block-comments
+                                       guile-block-comments
+                                       scheme-sexp-comments
+                                       janet-long-strings
+                                       hy-bracket-strings)
+                             :value-type boolean))
+  :group 'parinfer-rust-mode)
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -318,15 +382,18 @@ Used for toggling between paren mode and last active mode.")
 
 Good for switching modes, after an undo, or when first starting
 parinfer."
-  (setq-local parinfer-rust--previous-options (parinfer-rust--generate-options
-                                               (parinfer-rust-make-option)
-                                               (parinfer-rust-make-changes)))
-  (setq-local parinfer-rust--previous-buffer-text (buffer-substring-no-properties
-                                                   (point-min)
-                                                   (point-max)))
-  (setq-local parinfer-rust--changes nil)
-  (setq-local parinfer-rust--disable nil))
-
+  (let ((major-mode-defaults (or (plist-get parinfer-rust-major-mode-options major-mode)
+                                 parinfer-rust--default-options)))
+    (setq-local parinfer-rust--previous-options (parinfer-rust--generate-options
+                                                 (parinfer-rust--set-options
+                                                   (parinfer-rust-make-option)
+                                                   major-mode-defaults)
+                                                 (parinfer-rust-make-changes)))
+    (setq-local parinfer-rust--previous-buffer-text (buffer-substring-no-properties
+                                                     (point-min)
+                                                     (point-max)))
+    (setq-local parinfer-rust--changes nil)
+    (setq-local parinfer-rust--disable nil)))
 
 ;; The idea for this function:
 ;;
@@ -659,4 +726,7 @@ not available."
     (parinfer-rust-mode-enable))))
 
 (provide 'parinfer-rust-mode)
+;;; Local Variables:
+;;; lisp-indent-function: common-lisp-indent-function
+;;; End:
 ;;; parinfer-rust-mode.el ends here

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -247,6 +247,71 @@ node `(elisp)Replacing'"
 
 (define-obsolete-variable-alias 'parinfer-rust--buffer-replace-strategy 'parinfer-rust-buffer-replace-strategy "0.8.7")
 
+(defvar parinfer-rust--option-type '(plist
+                                     :key-type symbol
+                                     :options ((:force-balance boolean)
+                                               (:return-parens boolean)
+                                               (:partial-result boolean)
+                                               (:lisp-vline-symbols boolean)
+                                               (:lisp-block-comments boolean)
+                                               (:guile-block-comments boolean)
+                                               (:scheme-sexp-comments boolean)
+                                               (:janet-long-strings boolean)
+                                               (:comment-char string)
+                                               (:string-delimiters (repeat string)))
+                                     :value-type (choice boolean string (vector string)))
+  "The available options to pass to the parinfer-rust library.
+
+These options are used to configure the behavior of the
+parinfer-rust library to handle special cases in different lisps
+and schemes.
+
+The available options are:
+
+  - `:force-balance': employ the aggressive paren-balancing rules
+    from v1.
+    - Type: boolean
+    - Default: nil
+
+  - `:return-parens': return the parens in the result text.
+    - Type: boolean
+    - Default: nil
+
+  - `:partial-result': return partially processed text/cursor if
+    an error occurs
+
+    - Type: boolean
+    - Default: nil
+
+  - `:lisp-vline-symbols': recognize |lisp-style vline symbol|s.
+    - Type: boolean
+    - Default: nil
+
+  - `:lisp-block-comments': recognize |lisp-style vline symbol|s.
+    - Type: boolean
+    - Default: nil
+
+  - `:guile-block-comments': recognize #!/guile/block/comments \\n!#
+    - Type: boolean
+    - Default: nil
+
+  - `:scheme-sexp-comments': recognize #;( scheme sexp comments )
+    - Type: boolean
+    - Default: nil
+
+  - `:janet-long-strings': recognize ``` janet-style long strings ```
+    - Type: boolean
+    - Default: nil
+
+  - `:comment-char': a character (ie: string of length 1) that
+    should be considered comments in the code
+    - Type: string
+    - Default: \";\"
+
+  - `:string-delimiters' - the delimiters used for strings.
+    - Type: (vector string)
+    - Default: [\"\\\"\"]")
+
 
 (defvar parinfer-rust--default-options '(:force-balance nil
                                          :return-parens nil
@@ -257,44 +322,77 @@ node `(elisp)Replacing'"
                                          :scheme-sexp-comments nil
                                          :janet-long-strings nil
                                          :comment-char ";"
-                                         :string-delimiters ("\"")))
-;; TODO: Make into a defcustom
-(defcustom parinfer-rust-major-mode-options
-  (list
-   'clojure-mode parinfer-rust--default-options
+                                         :string-delimiters ["\""])
+  "The set of options parinfer-rust considers default.
 
-   'janet-mode '(:comment-char "#")
+This is here mainly as reference for what is available to pass to
+the library and what needs to be changed for major mode specific
+implementations.")
 
-   'lisp-mode '(:lisp-vline-symbols t
-                :lisp-block-comments t)
+(defcustom parinfer-rust-clojure-options '()
+  "Options to configure parinfer-rust for clojure mode.
 
-   'racket-mode '(:lisp-vline-symbols t
-                  :lisp-block-comments t
-                  :scheme-sexp-comments t)
-
-   'guile-mode '(:lisp-vline-symbols t
-                 :lisp-block-comments t
-                 :guile-block-comments t
-                 :scheme-sexp-comments t)
-
-   'scheme-mode '(:lisp-vline-symbols t
-                  :lisp-block-comments t
-                  :scheme-sexp-comments t))
-  "Major mode specific options for `parinfer-rust-mode'."
-  :type '(plist :value-type (plist
-                             :key-type symbol
-                             :options ((:force-balance boolean)
-                                       (:return-parens boolean)
-                                       (:partial-result boolean)
-                                       (:lisp-vline-symbols boolean)
-                                       (:lisp-block-comments boolean)
-                                       (:guile-block-comments boolean)
-                                       (:scheme-sexp-comments boolean)
-                                       (:janet-long-strings boolean)
-                                       (:comment-char string)
-                                       (:string-delimiters (repeat string)))
-                             :value-type (choice boolean string (repeat string))))
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
   :group 'parinfer-rust-mode)
+
+(defcustom parinfer-rust-janet-options '(:comment-char "#")
+  "Options to configure parinfer-rust for janet.
+
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
+  :group 'parinfer-rust-mode)
+
+(defcustom parinfer-rust-lisp-options '(:lisp-vline-symbols t
+                                        :lisp-block-comments t)
+  "Options to configure parinfer-rust for LISP.
+
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
+  :group 'parinfer-rust-mode)
+
+(defcustom parinfer-rust-racket-options '(:lisp-vline-symbols t
+                                          :lisp-block-comments t
+                                          :scheme-sexp-comments t)
+  "Options to configure parinfer-rust for racket.
+
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
+  :group 'parinfer-rust-mode)
+
+(defcustom parinfer-rust-guile-options '(:lisp-vline-symbols t
+                                         :lisp-block-comments t
+                                         :guile-block-comments t
+                                         :scheme-sexp-comments t)
+  "Options to configure parinfer-rust for guile.
+
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
+  :group 'parinfer-rust-mode)
+
+(defcustom parinfer-rust-scheme-options '(:lisp-vline-symbols t
+                                          :lisp-block-comments t
+                                          :scheme-sexp-comments t)
+  "Options to configure parinfer-rust for scheme.
+
+See `parinfer-rust--option-type' for a more complete explanation of the options."
+  :type parinfer-rust--option-type
+  :group 'parinfer-rust-mode)
+
+(defvar parinfer-rust-major-mode-options
+  (list
+   'clojure-mode parinfer-rust-clojure-options
+
+   'janet-mode parinfer-rust-janet-options
+
+   'lisp-mode parinfer-rust-lisp-options
+
+   'racket-mode parinfer-rust-racket-options
+
+   'guile-mode parinfer-rust-guile-options
+
+   'scheme-mode parinfer-rust-scheme-options)
+  "Major mode specific options for that controls how the parinfer-rust library behaves.")
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setup
 ;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -417,9 +515,9 @@ parinfer."
 ;; Interfaces for parinfer-rust
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun parinfer-rust--set-options (options new-options)
-  "Update the `PREVIOUS-OPTIONS' with values in the plist `NEW-OPTIONS'.
+  "Update the `OPTIONS' with values in the plist `NEW-OPTIONS'.
 
-This mutates the current reference to `PREVIOUS-OPTIONS'
+This mutates the current reference to `OPTIONS'
 Ex:
   (parinfer-rust--set-options parinfer-rust--previous-options ;; '((:cursor-x . 1) (:cursor-line . 1))
                                '(:cursor-x 2 :cursor-line 2))
@@ -706,7 +804,5 @@ not available."
     (parinfer-rust-mode-enable))))
 
 (provide 'parinfer-rust-mode)
-;;; Local Variables:
-;;; lisp-indent-function: common-lisp-indent-function
-;;; End:
+
 ;;; parinfer-rust-mode.el ends here

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -296,6 +296,7 @@ command should be run in.")
 Either `paren', `indent', or `smart'.")
 (defvar-local parinfer-rust--previous-options nil
   "The last set of record of changes and meta information of changes in the buffer.")
+
 ;; TODO this might be not needed anymore
 (defvar-local parinfer-rust--disable nil "Temporarily disable parinfer.")
 (defvar-local parinfer-rust--previous-buffer-text ""

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -4,7 +4,7 @@
 
 ;; Author: Justin Barclay <justinbarclay@gmail.com>
 ;; URL: https://github.com/justinbarclay/parinfer-rust-mode
-;; Version: 0.8.8
+;; Version: 0.9.0
 ;; Package-Requires: ((emacs "26.1") (track-changes "1.1"))
 ;; Keywords: lisp tools
 

--- a/readme.org
+++ b/readme.org
@@ -6,7 +6,15 @@
 [[file:https://raw.githubusercontent.com/ocodo/parinfer-logo/master/pngs/parinfer-org-logo-128x128.png]]
 
 * Parinfer
-  [[https://shaunlebron.github.io/parinfer/][Parinfer]] is a plugin that aims to make writing lisp simple. This library is a minimalistic wrapper around [[https://github.com/eraserhd/parinfer-rust][eraserhd/parinfer-rust]] to provide an Emacs minor mode. parinfer-rust-mode aims to be a simpler adaptation of Parinfer that only offers "smart mode", leveraging the parinfer-rust plugin to do most of the heavy lifting.
+[[https://shaunlebron.github.io/parinfer/][Parinfer]] is a plugin that aims to make writing lisp simple. This library is a minimalistic wrapper around [[https://github.com/justinbarclay/parinfer-rust][justinbarclay/parinfer-rust-emacs]], an Emacs-centric fork of [[https://github.com/eraserhd/parinfer-rust][eraserhd/parinfer-rust]], to provide an Emacs minor mode. parinfer-rust-mode aims to be a simple implementation of Parinfer that leverages the parinfer-rust plugin to do most of the heavy lifting.
+
+#+begin_quote
+[!WARNING]
+Version 0.9 and greater of ~parinfer-rust-mode~ only supports my fork of ~parinfer-rust~, ~parinfer-rust-emacs~. My primary reason for forking was to add better support for ~parinfer-rust~ options, which will allow ~parinfer-rust-mode~ to work better with non-clojure-like lisps. You can read more [[https://github.com/justinbarclay/parinfer-rust/discussions/9][here]].
+
+For those wanting to continue using ~parinfer-rust~, you should pin your install to version 0.8.5.
+#+end_quote
+
 ** Capabilities:
    - Making code auto-adhere to formatting conventions
    - Influencing expression-nesting with indentation
@@ -72,9 +80,9 @@ If you are using the ==use-package== snippet from above, that would look like:
 
 [fn:1] Don't see your OS/Arch on here? Feel free to open up a PR at [[https://github.com/justinbarclay/parinfer-rust][parinfer-rust-emacs]] and add your OS to the GitHub actions.
 **** Option 2: Building library from sources
-For the more adventurous of you, you can also download the ~parinfer-rust~ library from source and compile it.
-***** Step 1: Build the Parinfer Rust library
-     When compiling manually the library name differs from platform to platform. Additionally, Emacs expects that these libraries have specific file extensions when first loading them up. This is a problem for MacOS because Rust compiles it as ~.dylib~ and we'll need to give the file an ~.so~ extension when we copy it to it's final location.
+For the more adventurous, you can also download and compile the ~parinfer-rust~ library from source.
+***** Step 1: Build the Parinfer Rust Emacs library
+     When manually compiling the library, the file name differs from platform to platform. Additionally, Emacs expects that these libraries have specific file extensions when first loading them up. This is a problem for MacOS because Rust compiles it as ~.dylib~, and we'll need to give the file an ~.so~ extension when we copy it to its final location.
 
      | Platform | File name              | Required extension |
      |----------+------------------------+--------------------|
@@ -83,9 +91,9 @@ For the more adventurous of you, you can also download the ~parinfer-rust~ libra
      | Windows  | parinfer_rust.dll      | .dll               |
 
      #+BEGIN_SRC shell
-       git clone https://github.com/eraserhd/parinfer-rust.git
+       git clone https://github.com/justinbarclay/parinfer-rust-emacs.git
        cd parinfer-rust
-       cargo build --release --features emacs
+       cargo build --release
        cp ./target/release/${library-name} ~/.emacs.d/parinfer-rust/${lib-name}
      #+END_SRC
 ***** Step 2: Configure parinfer-rust-mode
@@ -271,3 +279,4 @@ Ran 143 tests in 0.061 seconds
    - Jason Felice for creating and maintaining the parinfer-rust project
    - tianshu for helping me fall in love with parinfer-mode in Emacs.
    - Andrey Orst for his contributions to this project
+   - Gerry Agbobada for adding support to customize options in parinfer-rust-emacs

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -112,7 +112,7 @@
                                     (parinfer-rust-version)
                                     parinfer-rust-library
                                     parinfer-rust--lib-name)
-      (indent-tabs-mode 0)
+      (setq-local parinfer-rust-disable-troublesome-modes t)
       ;; Disable checks for deferral and do not run --execute on initialization
       ;; this breaks a lot of test because they expect the buffer to be in a specific state
       (parinfer-rust-mode-setup))))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -101,11 +101,11 @@
 
 ;; Shadow function form parinfer-rust-mode because it executes buffer before everything is set-up in some test cases
 (define-minor-mode parinfer-rust-mode
-  "A simpler way to write lisps"
+    "A simpler way to write lisps"
   :lighter " parinfer"
   :init-value nil
   :keymap parinfer-rust-mode-map
-  (if parinfer-rust-mode
+  (if (not parinfer-rust-mode)
       (parinfer-rust-mode-disable)
     (progn
       (parinfer-rust--check-version parinfer-rust-supported-versions

--- a/test/user-submitted-cases.el
+++ b/test/user-submitted-cases.el
@@ -240,6 +240,15 @@
                                                           (plist-get test :setup))
       (plist-get test :after)))))
 
+(ert-deftest handles-brackets-in-strings ()
+  (let ((before
+         "(map! \"] E\")")
+        (changes
+         nil)
+        (after
+         "(map! \"] E\")"))
+    (should (equal (simulate-parinfer-in-another-buffer before "paren" changes)
+                   after))))
 ;;; Local Variables:
 ;;; lisp-indent-function: common-lisp-indent-function
 ;;; End:

--- a/test/user-submitted-cases.el
+++ b/test/user-submitted-cases.el
@@ -46,12 +46,12 @@
 
 (ert-deftest setting-options-works ()
   (let* ((settings (list :lisp-vline-symbols t
-                     :lisp-block-comments t
-                     :guile-block-comments nil
-                     :scheme-sexp-comments t
-                     :janet-long-strings nil
-                     :comment-char "#"
-                     :string-delimiters (list "\"")))
+                         :lisp-block-comments t
+                         :guile-block-comments nil
+                         :scheme-sexp-comments t
+                         :janet-long-strings nil
+                         :comment-char "#"
+                         :string-delimiters (list "\"")))
          (keys (mapcar #'car (seq-partition settings 2)))
          (options (parinfer-rust-make-option)))
     (parinfer-rust--set-options
@@ -69,8 +69,8 @@
 (ert-deftest user-fill-paragraph ()
   (let ((test
          '(:setup (clojure-mode)
-                  :before
-                  "(ns some-namespace.core
+           :before
+           "(ns some-namespace.core
   (:import [java.util.concurrent Executors])
   (:require [clojure.string :as string]))
 
@@ -78,8 +78,8 @@
   \"pretty long docsting that will be affected by `fill-paragraph` function\"
   [x]
   x)"
-                  :after
-                  "(ns some-namespace.core
+           :after
+           "(ns some-namespace.core
   (:import [java.util.concurrent Executors])
   (:require [clojure.string :as string]))
 
@@ -88,7 +88,7 @@
   function\"
   [x]
   x)"
-                  :commands (((:lineNo 6 :column 4) fill-paragraph)))))
+           :commands (((:lineNo 6 :column 4) fill-paragraph)))))
     (should
      (string=
       (simulate-parinfer-in-another-buffer--with-commands (plist-get test :before)
@@ -102,8 +102,7 @@
 (ert-deftest use-paredit-barf-sexp ()
   (let ((test
          '(:setup
-           (clojure-mode paredit-mode
-                         )
+           (clojure-mode paredit-mode)
            :before
            "(foo- _foo [foo foo]
       (foo/foo foo {:foo foo-foo
@@ -166,21 +165,21 @@
     (add-to-list 'parinfer-rust-treat-command-as '(indent-buffer . "paren")))
   (let ((test
          '(:setup (clojure-mode add-func-to-treat-command-as)
-                  :before
-                  "               (defn vaiv []
+           :before
+           "               (defn vaiv []
         \"I am incorrect\"
    (let
  [a 1
          b 2]
                       (+ a b)))"
-                  :after
-                  "(defn vaiv []
+           :after
+           "(defn vaiv []
   \"I am incorrect\"
   (let
       [a 1
        b 2]
     (+ a b)))"
-                  :commands (((:lineNo 0 :column 0) indent-buffer)))))
+           :commands (((:lineNo 0 :column 0) indent-buffer)))))
     (should
      (string=
       (simulate-parinfer-in-another-buffer--with-commands (plist-get test :before)
@@ -228,10 +227,10 @@
 (ert-deftest doesnt-handles-utf-8 ()
   (let ((test
          '(:before
-                  "(func 中)"
-                  :after
-                  "(func 中 )"
-                  :commands (((:lineNo 0 :column 8) (lambda () (insert " ")))))))
+           "(func 中)"
+           :after
+           "(func 中 )"
+           :commands (((:lineNo 1 :column 8) (lambda () (insert " ")))))))
     (should-not
      (string=
       (simulate-parinfer-in-another-buffer--with-commands (plist-get test :before)
@@ -249,6 +248,31 @@
          "(map! \"] E\")"))
     (should (equal (simulate-parinfer-in-another-buffer before "paren" changes)
                    after))))
+
+(ert-deftest handles-deleting-whitespace-before-sexp ()
+  (let ((test
+         '(:before
+           "(thing
+ (defmacro foo nil
+  :a b
+  :b c
+  \"A doc comment\"))"
+           :after "(thing)
+(defmacro foo nil
+  :a b
+  :baz bar
+  :version \"29.1\"
+  \"A doc comment\")"
+           :commands (((:lineNo 2 :column 1) (lambda () (delete-backward-char 1)))
+                      ((:lineNo 1 :column 5) newline-and-indent)
+                      ((:lineNo 2 :column 1) (lambda () (delete-backward-char 1)))))))
+    (should-not
+     (string=
+      (simulate-parinfer-in-another-buffer--with-commands (plist-get test :before)
+                                                          "smart"
+                                                          (plist-get test :commands)
+                                                          (plist-get test :setup))
+      (plist-get test :after)))))
 ;;; Local Variables:
 ;;; lisp-indent-function: common-lisp-indent-function
 ;;; End:

--- a/test/user-submitted-cases.el
+++ b/test/user-submitted-cases.el
@@ -44,6 +44,25 @@
                                                           (plist-get test :commands))
       (plist-get test :after)))))
 
+(ert-deftest setting-options-works ()
+  (let* ((settings (list :lisp-vline-symbols t
+                     :lisp-block-comments t
+                     :guile-block-comments nil
+                     :scheme-sexp-comments t
+                     :janet-long-strings nil
+                     :comment-char "#"
+                     :string-delimiters (vector "\"")))
+         (keys (mapcar #'car (seq-partition settings 2)))
+         (options (parinfer-rust-make-option)))
+    (parinfer-rust--set-options
+     options
+     settings)
+    (equal settings
+           (cl-reduce (lambda (acc key)
+                        (append acc  (list key (parinfer-rust-get-option options key))))
+                      keys
+                      :initial-value '()))))
+
 ;; This covers issue #9
 ;; we expect fill paragraph to not cause the rest of the buffer to be realigned
 ;; This requires clojure-mode... need to think about _including_ this mode specific test
@@ -220,3 +239,7 @@
                                                           (plist-get test :commands)
                                                           (plist-get test :setup))
       (plist-get test :after)))))
+
+;;; Local Variables:
+;;; lisp-indent-function: common-lisp-indent-function
+;;; End:

--- a/test/user-submitted-cases.el
+++ b/test/user-submitted-cases.el
@@ -51,7 +51,7 @@
                      :scheme-sexp-comments t
                      :janet-long-strings nil
                      :comment-char "#"
-                     :string-delimiters (vector "\"")))
+                     :string-delimiters (list "\"")))
          (keys (mapcar #'car (seq-partition settings 2)))
          (options (parinfer-rust-make-option)))
     (parinfer-rust--set-options


### PR DESCRIPTION
Update options handling to coincide with changes made in `parinfer-rust` v0.4.5`

TODO:
- [x] add `defcustom` to handle default plists for major modes
  - should this have a default that we use every?
- [x] add function to take new `defcustom` and apply options on parinfer-rust-mode start-up
- [x] look at code and come up with deprecation strategy/communication strategy for new changes and how my fork of `parinfer-rust` is the only useable one.
- [x] add tests to validate parinfer-rusts new api
- [x] add tests to handle new behavior for custom options setting
- [x] fix api of string-delimeters being vector. 
  -  for a pleasant API they need to be a list
- [x] maybe rename parinfer-rust fork to parinfer-rust-emacs