### PR TITLE
Add support to download the freebsd variant of parinfer-rust

### DIFF
--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -235,7 +235,12 @@ mode to better emulate users."
     (cond ((< num 0) 0)
           ((> num max) max)
           (t num))))
-
+(defun parinfer-rust--defer-loading (&rest _)
+  "Defer loading of `parinfer-rust-mode' until the buffer is in focus."
+  (when (eq (current-buffer)
+            (window-buffer (selected-window)))
+    (remove-hook 'window-selection-change-functions #'parinfer-rust--defer-loading t)
+    (parinfer-rust-mode)))
 ;; Disable fill column warning only for this buffer to enable long strings of text without
 ;; having to do a weird mapconcat.
 ;; Local Variables:

--- a/parinfer-rust-helper.el
+++ b/parinfer-rust-helper.el
@@ -50,6 +50,13 @@ Set this to non-nil to disable troublesome modes without prompting."
 (defconst parinfer-rust--ask-to-download "Could not find the parinfer-rust library, would you like to automatically download it from github?")
 (defconst parinfer-rust--outdated-version "You are using a parinfer-rust library that is not compatible with this file, would you like to download the appropriate file from github?")
 
+(defvar  parinfer-rust--download-url "https://github.com/justinbarclay/parinfer-rust/releases/download/v%s/%s"
+  "The url to download the parinfer-rust library from.
+
+This should be a format string that takes two arguments, the
+first is the version of the library and the second is the name of
+the library.")
+
 (defun parinfer-rust--check-for-library (supported-versions
                                          library-location
                                          lib-name
@@ -89,6 +96,7 @@ offer to download the LIB-NAME to LIBRARY-LOCATION."
     (parinfer-rust--download-from-github (car supported-versions) library-location lib-name)
     (message "A new version has been downloaded, you will need to reload Emacs for the changes to take effect.")))
 
+
 (defun parinfer-rust--download-from-github (parinfer-rust-version
                                             library-location
                                             lib-name)
@@ -101,7 +109,7 @@ Uses PARINFER-RUST-VERSION to download a compatible version of the library."
           (make-directory (file-name-directory library-location) t))
         (shell-command
          (format "curl -L %s -o %s"
-                 (format "https://github.com/justinbarclay/parinfer-rust/releases/download/v%s/%s"
+                 (format parinfer-rust--download-url
                          parinfer-rust-version
                          lib-name)
                  (expand-file-name library-location)))

--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -180,6 +180,10 @@ against and is known to be api compatible.")
 
 (defconst parinfer-rust--lib-name (cond
                                    ((eq system-type 'darwin) "parinfer-rust-darwin.so")
+                                   ((or
+                                     (eq system-type 'gnu/berkley)
+                                     (eq system-type 'berkley-unix))
+                                    "parinfer-rust-freebsd.so")
                                    ((eq system-type 'gnu/linux) "parinfer-rust-linux.so")
                                    ((eq system-type 'windows-nt) "parinfer-rust-windows.dll"))
   "System dependent library name for `parinfer-rust-mode'.")

--- a/readme.org
+++ b/readme.org
@@ -33,22 +33,33 @@ After that add it to your load path and go wild.
 Alternatively, you can tell something like [[https://github.com/quelpa/quelpa-use-package][use-package]] to manage it for you.
 #+BEGIN_SRC emacs-lisp
   (use-package parinfer-rust-mode
-    :hook emacs-lisp-mode)    
+    :hook emacs-lisp-mode)
 #+END_SRC
 
 *** parinfer-rust library
 You'll also need to have the library installed on your system for you somewhere.
 **** Option 1: Let Parinfer Rust install it for you
-That's it. There are no instructions here.[1] When parinfer-rust-mode prompts you to download the library, say yes. ~parinfer-rust-mode~ will then use curl to download ~parinfer-rust~ and save it in ~${EMACS_DIRECTORY}/parinfer-rust/~.
+That's it. There are no instructions here. When parinfer-rust-mode prompts you to download the library, say yes. ~parinfer-rust-mode~ will then use curl to download ~parinfer-rust~ and save it in ~${EMACS_DIRECTORY}/parinfer-rust/~.
 
-If you're curious, you can find the library files that parinfer-rust-mode downloads as release artifacts for [[https://github.com/eraserhd/parinfer-rust/releases/tag/v0.4.3][parinfer-rust]].
+/Supported OS & Arch[fn:1]/
+#+NAME: Supported OS
+| Operating System | Architecture |
+| Windows          | x86_64       |
+| Darwin           | aarch64      |
+| Linux            | x86_64       |
+| Freebsd          | x86_64       |
+#+BEGIN_QUOTE
+List of supported operating systems and the architecture for which libraries are prebuilt
+#+END_QUOTE
+
+If you're curious, you can find the library files that parinfer-rust-mode downloads as release artifacts for [[https://github.com/eraserhd/parinfer-rust/releases][parinfer-rust-emacs]].
 
 If you would always like parinfer-rust-mode to keep the library version in sync for you, automatically download it, then add the following line into your config:
 #+BEGIN_SRC emacs-lisp
 (setq parinfer-rust-auto-download t)
 #+END_SRC
 
-If you are using the `use-package` snippet from above, that would look like:
+If you are using the ==use-package== snippet from above, that would look like:
 #+BEGIN_SRC emacs-lisp
   (use-package parinfer-rust-mode
       :hook emacs-lisp-mode
@@ -56,8 +67,7 @@ If you are using the `use-package` snippet from above, that would look like:
       (setq parinfer-rust-auto-download t))
 #+END_SRC
 
-[1] parinfer-rust-mode only supports auto-installing for Windows, Linux, and Arm MacOS. If you are running an intel mac you will need to compile yourself with as outlined in Option 2.
-
+[fn:1] Don't see your OS/Arch on here? Feel free to open up a PR at [[https://github.com/justinbarclay/parinfer-rust][parinfer-rust-emacs]] and add your OS to the GitHub actions.
 **** Option 2: Building library from sources
 For the more adventurous of you, you can also download the ~parinfer-rust~ library from source and compile it.
 ***** Step 1: Build the Parinfer Rust library
@@ -127,7 +137,7 @@ parinfer-rust-mode is purposefully light on option, but it does give a few optio
   #+BEGIN_QUOTE
    default: ~/.emacs.d/parinfer-rust/parinfer-rust-*.so
   #+END_QUOTE
-  
+
 - ~parinfer-rust-preferred-mode~
 
   The mode you want parinfer-rust-mode to start in.
@@ -142,7 +152,7 @@ parinfer-rust-mode is purposefully light on option, but it does give a few optio
 - ~parinfer-rust-check-before-enable~
 
   Perform check on indentation before enabling `parinfer-rust-mode'
-  
+
   If Parinfer detects that it needs to change the indentation in the before first running, it will prompt the user whether it is OK to adjust the indentation. If the user disagrees Parinfer will disable itself. The user may choose to get the prompt immediately whenever parinfer-rust-mode is enabled, defer it until the first change in the buffer, or disable it and never receive a prompt. When disabled, parinfer-rust-mode will run automatically balance the indentation for the user.
 
 Options:
@@ -198,12 +208,12 @@ Is parinfer misbehaving in ~smart-mode~? This could be due to a bug or because s
 
 You can extend to parinfer-rust-treat-command-as using ~add-to-list~ as shown below:
 #+BEGIN_SRC elisp
-  (add-to-list 'parinfer-rust-treat-command-as '(your-command . "paren")) 
+  (add-to-list 'parinfer-rust-treat-command-as '(your-command . "paren"))
   ;;or
   (add-to-list 'parinfer-rust-treat-command-as '(your-command . "indent"))
 #+END_SRC
 ** Contributing
-If you'd like to help contribute to the development of ~parinfer-rust-mode~ the only caveat interesting section of note is the testing framework. 
+If you'd like to help contribute to the development of ~parinfer-rust-mode~ the only caveat interesting section of note is the testing framework.
 
 ~parinfer-rust-mode~ relies on [[https://github.com/cask/cask][Cask]] to manage development libraries and to set-up the tests themselves.
 


### PR DESCRIPTION
Plus some other small things
+ extract download-url to it's own var
+ don't run parinfer-rust-mode when until the buffer has been brought to foreground

closes: #52 #37 