### PR TITLE
Fix toggle typo in readme.org

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -117,11 +117,11 @@ Parinfer can operate under three different modes when writing lisp.
 
     [[./videos/smart-mode.gif]]
 ** Commands
-   | Command                      | Description                                           |
-   |------------------------------+-------------------------------------------------------|
-   | parinfer-switch-mode         | Quickly switch between paren, indent, and smart modes |
-   | parinfer-rust-toggle-disable | Toggle parinfer-rust-mode mode on or off              |
-   | parinfer-rust-toggle-paren   | Toggle between paren mode and current mode            |
+   | Command                         | Description                                           |
+   |---------------------------------+-------------------------------------------------------|
+   | parinfer-switch-mode            | Quickly switch between paren, indent, and smart modes |
+   | parinfer-rust-toggle-disable    | Toggle parinfer-rust-mode mode on or off              |
+   | parinfer-rust-toggle-paren-mode | Toggle between paren mode and current mode            |
 
    These commands are no longer bound to the ~C-c C-p~ prefix keys by default.
    If you prefer to use the old bindings, add this to your configuration (keep in mind it may clash with some major mode bindings):

--- a/readme.org
+++ b/readme.org
@@ -117,11 +117,11 @@ Parinfer can operate under three different modes when writing lisp.
 
     [[./videos/smart-mode.gif]]
 ** Commands
-   | Command                    | Description                                           |
-   |----------------------------+-------------------------------------------------------|
-   | parinfer-switch-mode       | Quickly switch between paren, indent, and smart modes |
-   | parinfer-rust-mode-disable | Toggle parinfer-rust-mode mode on or off              |
-   | parinfer-rust-toggle-paren | Toggle between paren mode and current mode            |
+   | Command                      | Description                                           |
+   |------------------------------+-------------------------------------------------------|
+   | parinfer-switch-mode         | Quickly switch between paren, indent, and smart modes |
+   | parinfer-rust-toggle-disable | Toggle parinfer-rust-mode mode on or off              |
+   | parinfer-rust-toggle-paren   | Toggle between paren mode and current mode            |
 
    These commands are no longer bound to the ~C-c C-p~ prefix keys by default.
    If you prefer to use the old bindings, add this to your configuration (keep in mind it may clash with some major mode bindings):


### PR DESCRIPTION
It's not obvious to me that this is the correct fix, but I believe `parinfer-rust-mode-disable`, while a function, is not an interactive command that could be called with `M-x` or bound to a key. The example keybindings below matched the other two commands and used `parinfer-rust-toggle-disable` instead, so I think that was supposed to have been in the table.