### PR TITLE
fix: bug where `this-command` is nil

### DIFF
--- a/parinfer-rust-mode.el
+++ b/parinfer-rust-mode.el
@@ -582,7 +582,9 @@ CHANGES."
       (let* ((parinfer-rust--mode
               (if-let ((mode
                         (and (string= "smart" parinfer-rust--mode)
-                             (alist-get this-command parinfer-rust-treat-command-as))))
+                             (alist-get (or this-command
+                                            last-command)
+                                        parinfer-rust-treat-command-as))))
                   (progn
                     ;; By saying a command should run under another mode, we're
                     ;; going to simplify parinfer-rust's behavior and clear all


### PR DESCRIPTION
This bug was introduce after switching to `track-changes` library. This is because we've relinquished control for when parinfer-rust-execute is called. `track-changes` calls it whenever it feels like it. That means `parinfer-rust-execute` can be called during a command execution, or after. We still have to prefer `this-command` first, because `last-command` has out of date information if `this-command` is not nil.

fixes #106 